### PR TITLE
Set up Dependabot weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # npm依存関係の更新設定
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "22:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+
+  # GitHub Actionsの更新設定
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "22:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
- npm依存関係の自動更新を週次で実行
- GitHub Actionsの自動更新も週次で実行
- スケジュール: 毎週土曜日朝7時JST（金曜日22:00 UTC）