### PR TITLE
Update Dependabot schedule to JST 7am

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "friday"
-      time: "22:00"
-      timezone: "UTC"
+      day: "wednesday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
 
   # GitHub Actionsの更新設定
@@ -15,7 +15,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "friday"
-      time: "22:00"
-      timezone: "UTC"
+      day: "wednesday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10


### PR DESCRIPTION
- Changed schedule from Friday 22:00 UTC to Wednesday 07:00 JST (Asia/Tokyo)
- Note: Dependabot's weekly schedule only supports one day per configuration
- If twice-weekly updates are needed, interval can be changed to "daily"