### PR TITLE
目標金額ボタンを ×2, ÷2, -100万, +100万 に変更

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -95,40 +95,40 @@ export default function Home() {
                 />
                 <HStack gap={1}>
                   <Button
-                    onClick={() => setTargetAmount(prev => Math.max(0, prev - 10000))}
+                    onClick={() => setTargetAmount(prev => prev * 2)}
                     colorScheme="blue"
                     size="xs"
                     flex={1}
                     _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
                   >
-                    -1万
+                    ×2
                   </Button>
                   <Button
-                    onClick={() => setTargetAmount(prev => prev + 10000)}
+                    onClick={() => setTargetAmount(prev => Math.max(0, Math.floor(prev / 2)))}
                     colorScheme="blue"
                     size="xs"
                     flex={1}
                     _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
                   >
-                    +1万
+                    ÷2
                   </Button>
                   <Button
-                    onClick={() => setTargetAmount(prev => Math.max(0, prev - 100000))}
+                    onClick={() => setTargetAmount(prev => Math.max(0, prev - 1000000))}
                     colorScheme="blue"
                     size="xs"
                     flex={1}
                     _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
                   >
-                    -10万
+                    -100万
                   </Button>
                   <Button
-                    onClick={() => setTargetAmount(prev => prev + 100000)}
+                    onClick={() => setTargetAmount(prev => prev + 1000000)}
                     colorScheme="blue"
                     size="xs"
                     flex={1}
                     _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
                   >
-                    +10万
+                    +100万
                   </Button>
                 </HStack>
               </VStack>


### PR DESCRIPTION
目標金額の調整ボタンを従来の ±1万/±10万 から、
より大きな金額調整に適した ×2, ÷2, -100万, +100万 に変更。

https://claude.ai/code/session_01SPurTf2jpva9xHkF4hiXk4