### PR TITLE
Add explanatory text for total savings calculation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -295,6 +295,9 @@ export default function Home() {
                 <Text fontSize="2xl" fontWeight="bold" color="green.600" _dark={{ color: "green.400" }}>
                   {(monthlyAmount * simulationData.months).toLocaleString()}円
                 </Text>
+                <Text fontSize="sm" color="gray.500">
+                  （毎月の積立額×達成月数）
+                </Text>
               </Box>
 
               <Box bg="purple.50" _dark={{ bg: "purple.900" }} p={4} borderRadius="lg">


### PR DESCRIPTION
## Summary
Added a clarifying subtitle beneath the total savings amount to help users understand how the calculation is derived.

## Key Changes
- Added explanatory text "（毎月の積立額×達成月数）" (Monthly savings amount × Number of months achieved) below the total savings display
- Uses small font size (sm) and gray color (gray.500) to maintain visual hierarchy while providing helpful context

## Implementation Details
- The new text element is positioned directly below the total savings amount in the savings summary section
- Styling is consistent with the dark mode support already present in the component
- This improves UX by making the calculation formula transparent to users

https://claude.ai/code/session_01L6Y2PEhH3pvv36NwZfgZmQ