### PR TITLE
グラフの表示を半年ごとに間引いて見やすくする

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -109,6 +109,18 @@ export default function Home() {
     return { data, months: month, finalAmount: currentSavings + investmentAmount, targetDate };
   }, [targetAmount, currentSavings, monthlyAmount, annualReturn, startYear, startMonth]);
 
+  // グラフ表示用に半年（6ヶ月）ごとへ間引く（最終点＝目標達成月は必ず含める）
+  const chartData = useMemo(() => {
+    const { data } = simulationData;
+    if (data.length === 0) return data;
+    const sampled = data.filter((point) => point.month % 6 === 0);
+    const lastPoint = data[data.length - 1];
+    if (sampled[sampled.length - 1]?.month !== lastPoint.month) {
+      sampled.push(lastPoint);
+    }
+    return sampled;
+  }, [simulationData]);
+
   // 年間積立額の計算
   const estimatedAnnualIncome = useMemo(() => {
     return monthlyAmount * 12;
@@ -637,7 +649,7 @@ export default function Home() {
 
             <Box h="400px">
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={simulationData.data}>
+                <LineChart data={chartData}>
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis
                     dataKey="monthLabel"


### PR DESCRIPTION
毎月のデータポイントでは細かすぎたため、グラフ表示用に6ヶ月ごとへ
間引いたデータを使用するように変更。目標達成月の最終点は必ず含める。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y6RJrJrzsPo9GcxzHep4xF