### PR TITLE
feat: change default dividend yield to 4% to align with the 4% rule

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,7 +40,7 @@ const DEFAULTS = {
   currentSavings: 14000000, // 現在の貯蓄額（1400万円）
   monthlyAmount: 300000, // 毎月の積立額（30万円）
   annualReturn: 5, // 年利（%）
-  dividendYield: 5, // 配当利回り（%）
+  dividendYield: 4, // 配当利回り（%）4%ルールに合わせたデフォルト値
   targetMonthlyDividend: 200000, // 目標の毎月配当額（20万円）
   startYear: CURRENT_YEAR, // 計算開始年
   startMonth: CURRENT_MONTH, // 計算開始月（1-12）


### PR DESCRIPTION
## Summary
- Change the default dividend yield from 5% to 4% so the default calculation follows the 4% rule (required assets = 25x annual spending)
- With the default target of ¥200,000/month, the required asset amount now defaults to ¥60,000,000 (¥2.4M / 4%)

## Changes
- `DEFAULTS.dividendYield` in `app/page.tsx`: 5 → 4
- All UI labels render dynamically from state, so no other changes were needed
- The annual return assumption for the accumulation simulation (5%) is unchanged, as it is a separate assumption from the withdrawal rule