### PR TITLE
feat: show monthly dividend projection in chart and merge settings into single view

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine } from 'recharts';
 import { useTheme } from 'next-themes';
 import { ThemeToggle } from './components/ThemeToggle';
 import {
@@ -72,18 +72,15 @@ export default function Home() {
     setMarket(DEFAULTS.market);
   };
 
-  // 毎月配当シミュレーション（目標の毎月配当額から必要な資産額を逆算）
-  const dividendSimulation = useMemo(() => {
+  // 目標の毎月配当額から必要な資産額を逆算（app/page.tsx requiredAmount）
+  // 積立シミュレーションの目標額として使用する
+  const requiredAmount = useMemo(() => {
     const annualDividend = targetMonthlyDividend * 12;
-    const requiredAmount = dividendYield > 0 ? annualDividend / (dividendYield / 100) : 0;
-    const afterTaxMonthly = targetMonthlyDividend * (1 - MARKETS[market].taxRate);
-    const shortfall = Math.max(0, requiredAmount - currentSavings);
-    const progress = requiredAmount > 0 ? Math.min(100, (currentSavings / requiredAmount) * 100) : 0;
-    return { annualDividend, requiredAmount, afterTaxMonthly, shortfall, progress };
-  }, [targetMonthlyDividend, dividendYield, currentSavings, market]);
+    return dividendYield > 0 ? annualDividend / (dividendYield / 100) : 0;
+  }, [targetMonthlyDividend, dividendYield]);
 
-  // 積立シミュレーションの計算（目標額は配当シミュレーションの必要資産額を使用）
-  const targetAmount = Math.round(dividendSimulation.requiredAmount);
+  // 積立シミュレーションの計算（目標額は必要資産額を使用）
+  const targetAmount = Math.round(requiredAmount);
   const simulationData = useMemo(() => {
     const data = [];
     let investmentAmount = 0; // 積立額と運用益（年利が適用される部分）
@@ -120,17 +117,27 @@ export default function Home() {
     return { data, months: month, finalAmount: currentSavings + investmentAmount, targetDate };
   }, [targetAmount, currentSavings, monthlyAmount, annualReturn, startYear, startMonth]);
 
-  // グラフ表示用に半年（6ヶ月）ごとへ間引く（最終点＝目標達成月は必ず含める）
+  // グラフ表示用データ（app/page.tsx chartData）
+  // 半年（6ヶ月）ごとへ間引き（最終点＝目標達成月は必ず含める）、
+  // 各時点の資産総額から月間配当額（税引前・税引後）を算出する
   const chartData = useMemo(() => {
     const { data } = simulationData;
-    if (data.length === 0) return data;
+    if (data.length === 0) return [];
     const sampled = data.filter((point) => point.month % 6 === 0);
     const lastPoint = data[data.length - 1];
     if (sampled[sampled.length - 1]?.month !== lastPoint.month) {
       sampled.push(lastPoint);
     }
-    return sampled;
-  }, [simulationData]);
+    const taxRate = MARKETS[market].taxRate;
+    return sampled.map((point) => {
+      const monthlyDividend = point.amount * dividendYield / 100 / 12;
+      return {
+        ...point,
+        monthlyDividend: Math.round(monthlyDividend),
+        monthlyDividendAfterTax: Math.round(monthlyDividend * (1 - taxRate)),
+      };
+    });
+  }, [simulationData, dividendYield, market]);
 
   // 年間積立額の計算
   const estimatedAnnualIncome = useMemo(() => {
@@ -138,14 +145,14 @@ export default function Home() {
   }, [monthlyAmount]);
 
   return (
-    <Box minH="100vh" p={8} bgGradient="linear(to-br, blue.50, purple.100)" _dark={{ bgGradient: "linear(to-br, gray.900, gray.800)" }}>
+    <Box minH="100vh" p={{ base: 4, md: 6 }} bgGradient="linear(to-br, blue.50, purple.100)" _dark={{ bgGradient: "linear(to-br, gray.900, gray.800)" }}>
       <Container maxW="container.xl">
-        <Flex justify="space-between" align="center" mb={8}>
+        <Flex justify="space-between" align="center" mb={4}>
           <Box flex={1}>
-            <Heading as="h1" size="2xl" textAlign="center" mb={2}>
+            <Heading as="h1" size="xl" textAlign="center">
               Road to FIRE
             </Heading>
-            <Text textAlign="center" fontSize="lg">
+            <Text textAlign="center" fontSize="sm" color="gray.500">
               積立投資シミュレーター
             </Text>
           </Box>
@@ -153,452 +160,358 @@ export default function Home() {
         </Flex>
 
         <Card.Root mb={8}>
-          <Card.Body p={6}>
-            <Heading as="h2" size="xl" mb={1}>毎月配当シミュレーション</Heading>
-            <Text fontSize="sm" color="gray.500" mb={6}>
-              毎月受け取りたい配当額から、必要な資産額を逆算します
-            </Text>
+          <Card.Body p={{ base: 4, md: 6 }}>
+            <Flex direction={{ base: 'column', lg: 'row' }} gap={6} align="stretch">
+              {/* 左カラム: 設定パネル */}
+              <Box w={{ base: '100%', lg: '340px' }} flexShrink={0}>
+                <Flex justify="space-between" align="center" mb={3}>
+                  <Heading as="h2" size="md">設定</Heading>
+                  <Button
+                    onClick={handleReset}
+                    size="xs"
+                    variant="outline"
+                    colorScheme="gray"
+                    _dark={{ borderColor: "gray.600", color: "gray.300", _hover: { bg: "gray.700" } }}
+                  >
+                    初期化
+                  </Button>
+                </Flex>
 
-            <SimpleGrid columns={{ base: 1, lg: 2 }} gap={6}>
-              <VStack align="stretch" gap={2}>
-                <Text fontSize="sm" fontWeight="medium">
-                  目標の毎月配当額（円）
-                </Text>
-                <Input
-                  type="text"
-                  inputMode="numeric"
-                  autoComplete="off"
-                  value={targetMonthlyDividend.toLocaleString()}
-                  onChange={(e) => {
-                    const value = e.target.value.replace(/,/g, '');
-                    if (!isNaN(Number(value))) {
-                      setTargetMonthlyDividend(Math.max(0, Number(value)));
-                    }
-                  }}
-                />
-                <HStack gap={1}>
-                  <Button
-                    onClick={() => setTargetMonthlyDividend(prev => Math.max(0, prev - 100000))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    -10万
-                  </Button>
-                  <Button
-                    onClick={() => setTargetMonthlyDividend(prev => Math.max(0, prev - 10000))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    -1万
-                  </Button>
-                  <Button
-                    onClick={() => setTargetMonthlyDividend(prev => prev + 10000)}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    +1万
-                  </Button>
-                  <Button
-                    onClick={() => setTargetMonthlyDividend(prev => prev + 100000)}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    +10万
-                  </Button>
-                </HStack>
-                <Text fontSize="sm" color="gray.500" mt={2}>
-                  配当利回り {dividendYield}%（「設定」で変更できます）
-                </Text>
-
-                <Box mt={3}>
-                  <Flex justify="space-between" mb={1}>
-                    <Text fontSize="xs" color="gray.500">
-                      現在の貯蓄額（{currentSavings.toLocaleString()}円）での達成率
+                <VStack align="stretch" gap={4}>
+                  <VStack align="stretch" gap={1}>
+                    <Text fontSize="sm" fontWeight="medium">
+                      計算開始年月
                     </Text>
-                    <Text fontSize="xs" fontWeight="semibold">
-                      {dividendSimulation.progress.toFixed(1)}%
+                    <HStack gap={2}>
+                      <Input
+                        type="number"
+                        inputMode="numeric"
+                        autoComplete="off"
+                        size="sm"
+                        value={startYear}
+                        onChange={(e) => {
+                          const value = Number(e.target.value);
+                          if (!isNaN(value)) {
+                            setStartYear(value);
+                          }
+                        }}
+                        min={1900}
+                        max={2100}
+                      />
+                      <Text fontSize="sm" color="gray.500">年</Text>
+                      <Input
+                        type="number"
+                        inputMode="numeric"
+                        autoComplete="off"
+                        size="sm"
+                        value={startMonth}
+                        onChange={(e) => {
+                          const value = Number(e.target.value);
+                          if (!isNaN(value) && value >= 1 && value <= 12) {
+                            setStartMonth(value);
+                          }
+                        }}
+                        min={1}
+                        max={12}
+                      />
+                      <Text fontSize="sm" color="gray.500">月</Text>
+                    </HStack>
+                  </VStack>
+
+                  <VStack align="stretch" gap={1}>
+                    <Text fontSize="sm" fontWeight="medium">
+                      現在の貯蓄額（円）
                     </Text>
-                  </Flex>
-                  <Box bg="gray.200" _dark={{ bg: "gray.700" }} borderRadius="full" h="10px" overflow="hidden">
-                    <Box
-                      bg="orange.400"
-                      h="100%"
-                      w={`${dividendSimulation.progress}%`}
-                      borderRadius="full"
-                      transition="width 0.3s"
-                    />
-                  </Box>
-                </Box>
-              </VStack>
-
-              <Box
-                bg="orange.50"
-                _dark={{ bg: "orange.900" }}
-                p={6}
-                borderRadius="lg"
-                display="flex"
-                flexDirection="column"
-                justifyContent="center"
-              >
-                <Text fontSize="sm" mb={1}>必要な資産額（税引前）</Text>
-                {dividendYield > 0 ? (
-                  <>
-                    <Text
-                      fontSize="4xl"
-                      fontWeight="bold"
-                      color="orange.600"
-                      _dark={{ color: "orange.400" }}
-                      lineHeight="1.1"
-                    >
-                      {Math.round(dividendSimulation.requiredAmount).toLocaleString()}円
-                    </Text>
-                    <Text fontSize="sm" color="gray.600" _dark={{ color: "gray.400" }} mt={2}>
-                      配当利回り{dividendYield}%で毎月{targetMonthlyDividend.toLocaleString()}円の配当を受け取るには、これだけの資産が必要です。
-                    </Text>
-                  </>
-                ) : (
-                  <Text fontSize="lg" fontWeight="medium" color="gray.500" mt={2}>
-                    「設定」で配当利回りを入力してください
-                  </Text>
-                )}
-              </Box>
-            </SimpleGrid>
-
-            <SimpleGrid columns={{ base: 1, md: 3 }} gap={4} mt={6}>
-              <Box bg="teal.50" _dark={{ bg: "teal.900" }} p={4} borderRadius="lg">
-                <Text fontSize="sm" mb={1}>年間配当額（税引前）</Text>
-                <Text fontSize="2xl" fontWeight="bold" color="teal.600" _dark={{ color: "teal.400" }}>
-                  {dividendSimulation.annualDividend.toLocaleString()}円
-                </Text>
-                <Text fontSize="sm" color="gray.500">（毎月の配当額×12）</Text>
-              </Box>
-
-              <Box bg="green.50" _dark={{ bg: "green.900" }} p={4} borderRadius="lg">
-                <Text fontSize="sm" mb={1}>税引後の毎月配当額（手取り）</Text>
-                <Text fontSize="2xl" fontWeight="bold" color="green.600" _dark={{ color: "green.400" }}>
-                  {Math.round(dividendSimulation.afterTaxMonthly).toLocaleString()}円
-                </Text>
-                <Text fontSize="sm" color="gray.500">（{MARKETS[market].label}・税率{MARKETS[market].taxRateLabel}で計算）</Text>
-              </Box>
-
-              <Box bg="blue.50" _dark={{ bg: "blue.900" }} p={4} borderRadius="lg">
-                <Text fontSize="sm" mb={1}>目標までの不足額</Text>
-                <Text fontSize="2xl" fontWeight="bold" color="blue.600" _dark={{ color: "blue.400" }}>
-                  {Math.round(dividendSimulation.shortfall).toLocaleString()}円
-                </Text>
-                <Text fontSize="sm" color="gray.500">（必要な資産額−現在の貯蓄額）</Text>
-              </Box>
-            </SimpleGrid>
-          </Card.Body>
-        </Card.Root>
-
-        <Card.Root mb={8}>
-          <Card.Body p={6}>
-            <Flex justify="space-between" align="center" mb={6}>
-              <Heading as="h2" size="xl">設定</Heading>
-              <Button
-                onClick={handleReset}
-                size="sm"
-                variant="outline"
-                colorScheme="gray"
-                _dark={{ borderColor: "gray.600", color: "gray.300", _hover: { bg: "gray.700" } }}
-              >
-                初期化
-              </Button>
-            </Flex>
-
-            <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={6}>
-              <VStack align="stretch">
-                <Text fontSize="sm" fontWeight="medium" mb={2}>
-                  計算開始年月
-                </Text>
-                <HStack gap={2}>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    autoComplete="off"
-                    value={startYear}
-                    onChange={(e) => {
-                      const value = Number(e.target.value);
-                      if (!isNaN(value)) {
-                        setStartYear(value);
-                      }
-                    }}
-                    min={1900}
-                    max={2100}
-                  />
-                  <Text fontSize="sm" color="gray.500">年</Text>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    autoComplete="off"
-                    value={startMonth}
-                    onChange={(e) => {
-                      const value = Number(e.target.value);
-                      if (!isNaN(value) && value >= 1 && value <= 12) {
-                        setStartMonth(value);
-                      }
-                    }}
-                    min={1}
-                    max={12}
-                  />
-                  <Text fontSize="sm" color="gray.500">月</Text>
-                </HStack>
-                <Text fontSize="xs" color="gray.500" mt={1}>
-                  シミュレーションの起点となる年月（デフォルトは今月）
-                </Text>
-              </VStack>
-
-              <VStack align="stretch">
-                <Text fontSize="sm" fontWeight="medium" mb={2}>
-                  現在の貯蓄額（円）
-                </Text>
-                <Input
-                  type="text"
-                  inputMode="numeric"
-                  autoComplete="off"
-                  value={currentSavings.toLocaleString()}
-                  onChange={(e) => {
-                    const value = e.target.value.replace(/,/g, '');
-                    if (!isNaN(Number(value))) {
-                      setCurrentSavings(Number(value));
-                    }
-                  }}
-                />
-                <HStack gap={1}>
-                  <Button
-                    onClick={() => setCurrentSavings(prev => Math.max(0, prev - 10000000))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    -1000万
-                  </Button>
-                  <Button
-                    onClick={() => setCurrentSavings(prev => Math.max(0, prev - 1000000))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    -100万
-                  </Button>
-                  <Button
-                    onClick={() => setCurrentSavings(prev => prev + 1000000)}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    +100万
-                  </Button>
-                  <Button
-                    onClick={() => setCurrentSavings(prev => prev + 10000000)}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    +1000万
-                  </Button>
-                </HStack>
-              </VStack>
-
-              <VStack align="stretch">
-                <Text fontSize="sm" fontWeight="medium" mb={2}>
-                  毎月の積立額（円）
-                </Text>
-                <Input
-                  type="text"
-                  inputMode="numeric"
-                  autoComplete="off"
-                  value={monthlyAmount.toLocaleString()}
-                  onChange={(e) => {
-                    const value = e.target.value.replace(/,/g, '');
-                    if (!isNaN(Number(value))) {
-                      setMonthlyAmount(Number(value));
-                    }
-                  }}
-                />
-                <HStack gap={1}>
-                  <Button
-                    onClick={() => setMonthlyAmount(prev => Math.max(0, prev - 100000))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    -10万
-                  </Button>
-                  <Button
-                    onClick={() => setMonthlyAmount(prev => Math.max(0, prev - 10000))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    -1万
-                  </Button>
-                  <Button
-                    onClick={() => setMonthlyAmount(prev => prev + 10000)}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    +1万
-                  </Button>
-                  <Button
-                    onClick={() => setMonthlyAmount(prev => prev + 100000)}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    +10万
-                  </Button>
-                </HStack>
-              </VStack>
-
-              <VStack align="stretch">
-                <Text fontSize="sm" fontWeight="medium" mb={2}>
-                  想定年利（%）
-                </Text>
-                <Input
-                  type="number"
-                  inputMode="decimal"
-                  autoComplete="off"
-                  value={annualReturn}
-                  onChange={(e) => setAnnualReturn(Number(e.target.value))}
-                  step={0.5}
-                  min={0}
-                  max={20}
-                />
-                <HStack gap={1}>
-                  <Button
-                    onClick={() => setAnnualReturn(prev => Math.max(0, prev - 1))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    -1
-                  </Button>
-                  <Button
-                    onClick={() => setAnnualReturn(prev => Math.min(20, prev + 1))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    +1
-                  </Button>
-                </HStack>
-              </VStack>
-
-              <VStack align="stretch">
-                <Text fontSize="sm" fontWeight="medium" mb={2}>
-                  配当利回り（%）
-                </Text>
-                <Input
-                  type="number"
-                  inputMode="decimal"
-                  autoComplete="off"
-                  value={dividendYield}
-                  onChange={(e) => setDividendYield(Number(e.target.value))}
-                  step={0.5}
-                  min={0}
-                  max={20}
-                />
-                <HStack gap={1}>
-                  <Button
-                    onClick={() => setDividendYield(prev => Math.max(0, prev - 1))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    -1
-                  </Button>
-                  <Button
-                    onClick={() => setDividendYield(prev => Math.min(20, prev + 1))}
-                    colorScheme="blue"
-                    size="xs"
-                    flex={1}
-                    _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
-                  >
-                    +1
-                  </Button>
-                </HStack>
-              </VStack>
-
-              <VStack align="stretch">
-                <Text fontSize="sm" fontWeight="medium" mb={2}>
-                  投資先（配当税率）
-                </Text>
-                <HStack gap={1}>
-                  {(Object.keys(MARKETS) as MarketKey[]).map((key) => (
-                    <Button
-                      key={key}
-                      onClick={() => setMarket(key)}
-                      colorScheme="blue"
+                    <Input
+                      type="text"
+                      inputMode="numeric"
+                      autoComplete="off"
                       size="sm"
-                      flex={1}
-                      variant={market === key ? 'solid' : 'outline'}
-                      _dark={market === key
-                        ? { bg: "blue.600", color: "white", _hover: { bg: "blue.500" } }
-                        : { borderColor: "gray.600", color: "gray.300", _hover: { bg: "gray.700" } }}
-                    >
-                      {MARKETS[key].label}
-                    </Button>
-                  ))}
-                </HStack>
-                <Text fontSize="xs" color="gray.500" mt={1}>
-                  国内: 20.315% / 海外（US）: 28.2835%（米国源泉10% + 国内課税20.315%。外国税額控除・NISAは考慮しません）
-                </Text>
-              </VStack>
-            </SimpleGrid>
-          </Card.Body>
-        </Card.Root>
+                      value={currentSavings.toLocaleString()}
+                      onChange={(e) => {
+                        const value = e.target.value.replace(/,/g, '');
+                        if (!isNaN(Number(value))) {
+                          setCurrentSavings(Number(value));
+                        }
+                      }}
+                    />
+                    <HStack gap={1}>
+                      <Button
+                        onClick={() => setCurrentSavings(prev => Math.max(0, prev - 10000000))}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        -1000万
+                      </Button>
+                      <Button
+                        onClick={() => setCurrentSavings(prev => Math.max(0, prev - 1000000))}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        -100万
+                      </Button>
+                      <Button
+                        onClick={() => setCurrentSavings(prev => prev + 1000000)}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        +100万
+                      </Button>
+                      <Button
+                        onClick={() => setCurrentSavings(prev => prev + 10000000)}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        +1000万
+                      </Button>
+                    </HStack>
+                  </VStack>
 
-        <Card.Root mb={8}>
-          <Card.Body p={6}>
-            <Heading as="h2" size="xl" mb={6}>FIREまでの道のり</Heading>
+                  <VStack align="stretch" gap={1}>
+                    <Text fontSize="sm" fontWeight="medium">
+                      毎月の積立額（円）
+                    </Text>
+                    <Input
+                      type="text"
+                      inputMode="numeric"
+                      autoComplete="off"
+                      size="sm"
+                      value={monthlyAmount.toLocaleString()}
+                      onChange={(e) => {
+                        const value = e.target.value.replace(/,/g, '');
+                        if (!isNaN(Number(value))) {
+                          setMonthlyAmount(Number(value));
+                        }
+                      }}
+                    />
+                    <HStack gap={1}>
+                      <Button
+                        onClick={() => setMonthlyAmount(prev => Math.max(0, prev - 100000))}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        -10万
+                      </Button>
+                      <Button
+                        onClick={() => setMonthlyAmount(prev => Math.max(0, prev - 10000))}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        -1万
+                      </Button>
+                      <Button
+                        onClick={() => setMonthlyAmount(prev => prev + 10000)}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        +1万
+                      </Button>
+                      <Button
+                        onClick={() => setMonthlyAmount(prev => prev + 100000)}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        +10万
+                      </Button>
+                    </HStack>
+                  </VStack>
 
-            <Box
-              bg="yellow.50"
-              _dark={{ bg: "yellow.900" }}
-              p={6}
-              borderRadius="lg"
-              mb={6}
-              textAlign="center"
-            >
-              <Text fontSize="sm" mb={2} color="gray.600" _dark={{ color: "gray.300" }}>
-                目標達成まで あと
-              </Text>
-              <HStack justify="center" align="baseline" gap={2} flexWrap="wrap">
-                <Text
-                  fontSize="6xl"
-                  fontWeight="bold"
-                  color="orange.600"
-                  _dark={{ color: "orange.300" }}
-                  lineHeight="1"
+                  <VStack align="stretch" gap={1}>
+                    <Text fontSize="sm" fontWeight="medium">
+                      目標の毎月配当額（円）
+                    </Text>
+                    <Input
+                      type="text"
+                      inputMode="numeric"
+                      autoComplete="off"
+                      size="sm"
+                      value={targetMonthlyDividend.toLocaleString()}
+                      onChange={(e) => {
+                        const value = e.target.value.replace(/,/g, '');
+                        if (!isNaN(Number(value))) {
+                          setTargetMonthlyDividend(Math.max(0, Number(value)));
+                        }
+                      }}
+                    />
+                    <HStack gap={1}>
+                      <Button
+                        onClick={() => setTargetMonthlyDividend(prev => Math.max(0, prev - 100000))}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        -10万
+                      </Button>
+                      <Button
+                        onClick={() => setTargetMonthlyDividend(prev => Math.max(0, prev - 10000))}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        -1万
+                      </Button>
+                      <Button
+                        onClick={() => setTargetMonthlyDividend(prev => prev + 10000)}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        +1万
+                      </Button>
+                      <Button
+                        onClick={() => setTargetMonthlyDividend(prev => prev + 100000)}
+                        colorScheme="blue"
+                        size="xs"
+                        flex={1}
+                        _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                      >
+                        +10万
+                      </Button>
+                    </HStack>
+                    <Text fontSize="xs" color="gray.500">
+                      この配当額に必要な資産額（配当利回りから逆算）が目標額になります
+                    </Text>
+                  </VStack>
+
+                  <SimpleGrid columns={2} gap={3}>
+                    <VStack align="stretch" gap={1}>
+                      <Text fontSize="sm" fontWeight="medium">
+                        想定年利（%）
+                      </Text>
+                      <Input
+                        type="number"
+                        inputMode="decimal"
+                        autoComplete="off"
+                        size="sm"
+                        value={annualReturn}
+                        onChange={(e) => setAnnualReturn(Number(e.target.value))}
+                        step={0.5}
+                        min={0}
+                        max={20}
+                      />
+                      <HStack gap={1}>
+                        <Button
+                          onClick={() => setAnnualReturn(prev => Math.max(0, prev - 1))}
+                          colorScheme="blue"
+                          size="xs"
+                          flex={1}
+                          _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                        >
+                          -1
+                        </Button>
+                        <Button
+                          onClick={() => setAnnualReturn(prev => Math.min(20, prev + 1))}
+                          colorScheme="blue"
+                          size="xs"
+                          flex={1}
+                          _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                        >
+                          +1
+                        </Button>
+                      </HStack>
+                    </VStack>
+
+                    <VStack align="stretch" gap={1}>
+                      <Text fontSize="sm" fontWeight="medium">
+                        配当利回り（%）
+                      </Text>
+                      <Input
+                        type="number"
+                        inputMode="decimal"
+                        autoComplete="off"
+                        size="sm"
+                        value={dividendYield}
+                        onChange={(e) => setDividendYield(Number(e.target.value))}
+                        step={0.5}
+                        min={0}
+                        max={20}
+                      />
+                      <HStack gap={1}>
+                        <Button
+                          onClick={() => setDividendYield(prev => Math.max(0, prev - 1))}
+                          colorScheme="blue"
+                          size="xs"
+                          flex={1}
+                          _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                        >
+                          -1
+                        </Button>
+                        <Button
+                          onClick={() => setDividendYield(prev => Math.min(20, prev + 1))}
+                          colorScheme="blue"
+                          size="xs"
+                          flex={1}
+                          _dark={{ bg: "gray.700", color: "blue.300", _hover: { bg: "gray.600" } }}
+                        >
+                          +1
+                        </Button>
+                      </HStack>
+                    </VStack>
+                  </SimpleGrid>
+
+                  <VStack align="stretch" gap={1}>
+                    <Text fontSize="sm" fontWeight="medium">
+                      投資先（配当税率）
+                    </Text>
+                    <HStack gap={1}>
+                      {(Object.keys(MARKETS) as MarketKey[]).map((key) => (
+                        <Button
+                          key={key}
+                          onClick={() => setMarket(key)}
+                          colorScheme="blue"
+                          size="sm"
+                          flex={1}
+                          variant={market === key ? 'solid' : 'outline'}
+                          _dark={market === key
+                            ? { bg: "blue.600", color: "white", _hover: { bg: "blue.500" } }
+                            : { borderColor: "gray.600", color: "gray.300", _hover: { bg: "gray.700" } }}
+                        >
+                          {MARKETS[key].label}
+                        </Button>
+                      ))}
+                    </HStack>
+                    <Text fontSize="xs" color="gray.500">
+                      国内: 20.315% / 海外（US）: 28.2835%（米国源泉10% + 国内課税20.315%。外国税額控除・NISAは考慮しません）
+                    </Text>
+                  </VStack>
+                </VStack>
+              </Box>
+
+              {/* 右カラム: FIREまでの道のり（達成予測＋月間配当グラフ＋サマリー） */}
+              <Box flex={1} minW={0}>
+                <Heading as="h2" size="md" mb={3}>FIREまでの道のり</Heading>
+
+                <Box
+                  bg="yellow.50"
+                  _dark={{ bg: "yellow.900" }}
+                  p={4}
+                  borderRadius="lg"
+                  mb={4}
+                  textAlign="center"
                 >
-                  {simulationData.months}
-                </Text>
-                <Text fontSize="2xl" fontWeight="semibold">ヶ月</Text>
-                {simulationData.months >= 12 && (
-                  <>
-                    <Text fontSize="xl" color="gray.500" mx={2}>＝</Text>
+                  <HStack justify="center" align="baseline" gap={2} flexWrap="wrap">
+                    <Text fontSize="sm" color="gray.600" _dark={{ color: "gray.300" }}>
+                      目標達成まで あと
+                    </Text>
                     <Text
                       fontSize="4xl"
                       fontWeight="bold"
@@ -606,132 +519,143 @@ export default function Home() {
                       _dark={{ color: "orange.300" }}
                       lineHeight="1"
                     >
-                      {Math.floor(simulationData.months / 12)}
+                      {simulationData.months}
                     </Text>
-                    <Text fontSize="xl" fontWeight="semibold">年</Text>
-                    {simulationData.months % 12 > 0 && (
+                    <Text fontSize="lg" fontWeight="semibold">ヶ月</Text>
+                    {simulationData.months >= 12 && (
                       <>
+                        <Text fontSize="lg" color="gray.500" mx={1}>＝</Text>
                         <Text
-                          fontSize="4xl"
+                          fontSize="3xl"
                           fontWeight="bold"
                           color="orange.600"
                           _dark={{ color: "orange.300" }}
                           lineHeight="1"
                         >
-                          {simulationData.months % 12}
+                          {Math.floor(simulationData.months / 12)}
                         </Text>
-                        <Text fontSize="xl" fontWeight="semibold">ヶ月</Text>
+                        <Text fontSize="lg" fontWeight="semibold">年</Text>
+                        {simulationData.months % 12 > 0 && (
+                          <>
+                            <Text
+                              fontSize="3xl"
+                              fontWeight="bold"
+                              color="orange.600"
+                              _dark={{ color: "orange.300" }}
+                              lineHeight="1"
+                            >
+                              {simulationData.months % 12}
+                            </Text>
+                            <Text fontSize="lg" fontWeight="semibold">ヶ月</Text>
+                          </>
+                        )}
                       </>
                     )}
-                  </>
-                )}
-              </HStack>
-              <Text fontSize="md" color="gray.600" _dark={{ color: "gray.300" }} mt={3}>
-                達成予定: <Text as="span" fontWeight="bold" color="orange.700" _dark={{ color: "orange.200" }}>
-                  {simulationData.targetDate.getFullYear()}年{simulationData.targetDate.getMonth() + 1}月頃
-                </Text>
-              </Text>
-            </Box>
+                    <Text fontSize="sm" color="gray.600" _dark={{ color: "gray.300" }} ml={2}>
+                      達成予定: <Text as="span" fontWeight="bold" color="orange.700" _dark={{ color: "orange.200" }}>
+                        {simulationData.targetDate.getFullYear()}年{simulationData.targetDate.getMonth() + 1}月頃
+                      </Text>
+                    </Text>
+                  </HStack>
+                </Box>
 
-            <Heading as="h2" size="xl" mb={4}>シミュレーション結果</Heading>
+                <Box h={{ base: '300px', md: '380px' }} mb={4}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={chartData}>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis
+                        dataKey="monthLabel"
+                        label={{ value: '年月', position: 'insideBottom', offset: -5 }}
+                      />
+                      <YAxis
+                        tickFormatter={(value) => `${(value / 10000).toFixed(0)}万`}
+                        label={{ value: '月間配当額（円/月）', angle: -90, position: 'insideLeft' }}
+                      />
+                      <Tooltip
+                        formatter={(value) => `${Number(value ?? 0).toLocaleString()}円/月`}
+                        labelFormatter={(label) => `${label}`}
+                        contentStyle={{
+                          backgroundColor: isDark ? '#1A202C' : '#FFFFFF',
+                          borderColor: isDark ? '#4A5568' : '#E2E8F0',
+                          color: isDark ? '#E2E8F0' : '#1A202C',
+                          borderRadius: '8px',
+                        }}
+                        labelStyle={{
+                          color: isDark ? '#A0AEC0' : '#4A5568',
+                        }}
+                        itemStyle={{
+                          color: isDark ? '#E2E8F0' : '#1A202C',
+                        }}
+                      />
+                      <Legend wrapperStyle={{ paddingTop: '20px' }} />
+                      <ReferenceLine
+                        y={targetMonthlyDividend}
+                        stroke="#ED8936"
+                        strokeDasharray="6 4"
+                        label={{
+                          value: `目標 ${(targetMonthlyDividend / 10000).toLocaleString()}万円/月`,
+                          position: 'insideTopRight',
+                          fill: '#ED8936',
+                          fontSize: 12,
+                        }}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="monthlyDividend"
+                        stroke="#8884d8"
+                        strokeWidth={2}
+                        name="月間配当額（税引前）"
+                        dot={{ r: 4 }}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="monthlyDividendAfterTax"
+                        stroke="#82ca9d"
+                        strokeWidth={2}
+                        name="月間配当額（税引後）"
+                        dot={{ r: 4 }}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </Box>
 
-            <SimpleGrid columns={{ base: 1, md: 2, lg: 5 }} gap={4} mb={6}>
-              <Box bg="blue.50" _dark={{ bg: "blue.900" }} p={4} borderRadius="lg">
-                <Text fontSize="sm" mb={1}>目標達成まで</Text>
-                <Text fontSize="2xl" fontWeight="bold" color="blue.600" _dark={{ color: "blue.400" }}>
-                  {simulationData.months}ヶ月
-                </Text>
-                <Text fontSize="sm" color="gray.500">
-                  （約{Math.round(simulationData.months / 12 * 10) / 10}年）
-                </Text>
-                <Text fontSize="sm" fontWeight="semibold" color="blue.700" _dark={{ color: "blue.300" }} mt={2}>
-                  {simulationData.targetDate.getFullYear()}年{simulationData.targetDate.getMonth() + 1}月頃
-                </Text>
+                <SimpleGrid columns={{ base: 2, xl: 4 }} gap={3}>
+                  <Box bg="green.50" _dark={{ bg: "green.900" }} p={3} borderRadius="lg">
+                    <Text fontSize="xs" mb={1}>総投資額</Text>
+                    <Text fontSize="lg" fontWeight="bold" color="green.600" _dark={{ color: "green.400" }}>
+                      {(currentSavings + monthlyAmount * simulationData.months).toLocaleString()}円
+                    </Text>
+                  </Box>
+
+                  <Box bg="purple.50" _dark={{ bg: "purple.900" }} p={3} borderRadius="lg">
+                    <Text fontSize="xs" mb={1}>運用益</Text>
+                    <Text fontSize="lg" fontWeight="bold" color="purple.600" _dark={{ color: "purple.400" }}>
+                      {Math.round(simulationData.finalAmount - currentSavings - monthlyAmount * simulationData.months).toLocaleString()}円
+                    </Text>
+                  </Box>
+
+                  <Box bg="orange.50" _dark={{ bg: "orange.900" }} p={3} borderRadius="lg">
+                    <Text fontSize="xs" mb={1}>現在の毎月配当額</Text>
+                    <Text fontSize="lg" fontWeight="bold" color="orange.600" _dark={{ color: "orange.400" }}>
+                      {Math.round(currentSavings * dividendYield / 100 / 12).toLocaleString()}円
+                    </Text>
+                    <Text fontSize="xs" color="gray.500">
+                      （現在の貯蓄額×配当利回り÷12）
+                    </Text>
+                  </Box>
+
+                  <Box bg="teal.50" _dark={{ bg: "teal.900" }} p={3} borderRadius="lg">
+                    <Text fontSize="xs" mb={1}>年間積立額</Text>
+                    <Text fontSize="lg" fontWeight="bold" color="teal.600" _dark={{ color: "teal.400" }}>
+                      {estimatedAnnualIncome.toLocaleString()}円
+                    </Text>
+                    <Text fontSize="xs" color="gray.500">
+                      （毎月の積立額×12）
+                    </Text>
+                  </Box>
+                </SimpleGrid>
               </Box>
-
-              <Box bg="green.50" _dark={{ bg: "green.900" }} p={4} borderRadius="lg">
-                <Text fontSize="sm" mb={1}>総投資額</Text>
-                <Text fontSize="2xl" fontWeight="bold" color="green.600" _dark={{ color: "green.400" }}>
-                  {(currentSavings + monthlyAmount * simulationData.months).toLocaleString()}円
-                </Text>
-              </Box>
-
-              <Box bg="purple.50" _dark={{ bg: "purple.900" }} p={4} borderRadius="lg">
-                <Text fontSize="sm" mb={1}>運用益</Text>
-                <Text fontSize="2xl" fontWeight="bold" color="purple.600" _dark={{ color: "purple.400" }}>
-                  {Math.round(simulationData.finalAmount - currentSavings - monthlyAmount * simulationData.months).toLocaleString()}円
-                </Text>
-              </Box>
-
-              <Box bg="orange.50" _dark={{ bg: "orange.900" }} p={4} borderRadius="lg">
-                <Text fontSize="sm" mb={1}>毎月の配当額</Text>
-                <Text fontSize="2xl" fontWeight="bold" color="orange.600" _dark={{ color: "orange.400" }}>
-                  {Math.round(currentSavings * dividendYield / 100 / 12).toLocaleString()}円
-                </Text>
-                <Text fontSize="sm" color="gray.500">
-                  （現在の貯蓄額×配当利回り÷12）
-                </Text>
-              </Box>
-
-              <Box bg="teal.50" _dark={{ bg: "teal.900" }} p={4} borderRadius="lg">
-                <Text fontSize="sm" mb={1}>年間積立額</Text>
-                <Text fontSize="2xl" fontWeight="bold" color="teal.600" _dark={{ color: "teal.400" }}>
-                  {estimatedAnnualIncome.toLocaleString()}円
-                </Text>
-                <Text fontSize="sm" color="gray.500">
-                  （毎月の積立額×12）
-                </Text>
-              </Box>
-            </SimpleGrid>
-
-            <Box h="400px">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis
-                    dataKey="monthLabel"
-                    label={{ value: '年月', position: 'insideBottom', offset: -5 }}
-                  />
-                  <YAxis
-                    tickFormatter={(value) => `${(value / 10000).toFixed(0)}万`}
-                    label={{ value: '金額（円）', angle: -90, position: 'insideLeft' }}
-                  />
-                  <Tooltip
-                    formatter={(value) => `${Number(value ?? 0).toLocaleString()}円`}
-                    labelFormatter={(label) => `${label}`}
-                    contentStyle={{
-                      backgroundColor: isDark ? '#1A202C' : '#FFFFFF',
-                      borderColor: isDark ? '#4A5568' : '#E2E8F0',
-                      color: isDark ? '#E2E8F0' : '#1A202C',
-                      borderRadius: '8px',
-                    }}
-                    labelStyle={{
-                      color: isDark ? '#A0AEC0' : '#4A5568',
-                    }}
-                    itemStyle={{
-                      color: isDark ? '#E2E8F0' : '#1A202C',
-                    }}
-                  />
-                  <Legend wrapperStyle={{ paddingTop: '20px' }} />
-                  <Line
-                    type="monotone"
-                    dataKey="amount"
-                    stroke="#8884d8"
-                    strokeWidth={2}
-                    name="資産総額"
-                    dot={{ r: 4 }}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="contribution"
-                    stroke="#82ca9d"
-                    strokeWidth={2}
-                    name="総投資額"
-                    dot={{ r: 4 }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </Box>
+            </Flex>
           </Card.Body>
         </Card.Root>
 


### PR DESCRIPTION
## Summary

- Change the chart to plot **monthly dividend income** (pre-tax and after-tax) instead of total assets / total contribution, so you can see at a glance how much dividend per month you would receive at each point in time (sampled every 6 months, as before). A dashed reference line marks the target monthly dividend.
- Remove the "毎月配当シミュレーション" card. The target monthly dividend input, which drives the goal amount calculation and the chart reference line, is moved into the settings panel.
- Merge the settings card and the "FIREまでの道のり" card into a single card with a two-column layout (settings on the left, goal countdown + chart + summary on the right), so everything fits in the first view on desktop. Falls back to a stacked layout on narrow screens.
- Compact the header, goal countdown banner, and summary boxes (the "目標達成まで" box was dropped as it duplicated the banner).

## Screenshots

First view at 1440x900 (verified with a local dev server): settings, countdown banner, monthly dividend chart with target line, and the 4 summary boxes are all visible without scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)