### PR TITLE
fix: relabel dividend yield as "yield" in UI

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,7 +57,7 @@ const DEFAULTS = {
   targetMonthlyDividend: 200000, // 目標の毎月配当額（20万円）
   startYear: CURRENT_YEAR, // 計算開始年
   startMonth: CURRENT_MONTH, // 計算開始月（1-12）
-  market: 'domestic' as MarketKey, // 投資先（配当税率の切り替えに使用）
+  market: 'us' as MarketKey, // 投資先（配当税率の切り替えに使用）
 };
 
 export default function Home() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -475,7 +475,7 @@ export default function Home() {
                           >
                             <VStack gap={0.5}>
                               <ScenarioIcon size={14} />
-                              <Text fontSize="xs" lineHeight="1.2">配当{scenario.dividendYield}%</Text>
+                              <Text fontSize="xs" lineHeight="1.2">利回り{scenario.dividendYield}%</Text>
                               <Text fontSize="xs" lineHeight="1.2">成長{scenario.growthRate}%</Text>
                             </VStack>
                           </Button>
@@ -527,7 +527,7 @@ export default function Home() {
 
                     <VStack align="stretch" gap={1}>
                       <Text fontSize="sm" fontWeight="medium">
-                        配当利回り（%）
+                        利回り（%）
                       </Text>
                       <Input
                         type="number"
@@ -571,7 +571,7 @@ export default function Home() {
                       </Text>
                     </HStack>
                     <Text fontSize="xs" color="gray.500">
-                      価格成長率 + 配当利回り × (1 − 配当税率)
+                      価格成長率 + 利回り × (1 − 税率)
                     </Text>
                   </Box>
 


### PR DESCRIPTION
## Problem

The scenario preset buttons and the rate input were labeled 配当 (dividend). However, the presets assume products like covered-call ETFs, SPYD, and J-REITs, whose payouts are technically 分配金 (distributions), not 配当 (dividends) — the label was inaccurate for two of the three presets.

Also, the market selection defaulted to 国内 (domestic), while US products are the primary use case.

## Change

Use the neutral term 利回り (yield) for the rate labels:

- Scenario preset buttons: 配当X% → 利回りX%
- Rate input label: 配当利回り（%） → 利回り（%）
- Effective annual return formula caption: 価格成長率 + 配当利回り × (1 − 配当税率) → 価格成長率 + 利回り × (1 − 税率)

Default the market selection (投資先) to 海外（US）.

価格成長率 (price growth rate) is accurate as-is and left unchanged. Amount labels (目標の毎月配当額, 月間配当額, etc.) are out of scope for this PR.

## Verification

Verified with screenshots that the new labels render correctly, 海外（US） is selected by default (effective annual return updates to 4.87% with the default inputs), and the page still fits within the first viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)