### PR TITLE
デフォルトのシナリオを強気（利回り7%・成長1%）に変更

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,8 +52,8 @@ const CURRENT_MONTH = TODAY.getMonth() + 1; // 1-indexed
 const DEFAULTS = {
   currentSavings: 14000000, // 現在の貯蓄額（1400万円）
   monthlyAmount: 300000, // 毎月の積立額（30万円）
-  growthRate: 2, // 価格成長率（%）配当利回り4%との組み合わせで実効年利が約5%になる想定
-  dividendYield: 4, // 配当利回り（%）高配当株ポートフォリオを想定したデフォルト値
+  growthRate: 1, // 価格成長率（%）強気シナリオ（カバードコールETF・BDC等）と同じ値
+  dividendYield: 7, // 配当利回り（%）強気シナリオを想定したデフォルト値
   targetMonthlyDividend: 200000, // 目標の毎月配当額（20万円）
   startYear: CURRENT_YEAR, // 計算開始年
   startMonth: CURRENT_MONTH, // 計算開始月（1-12）


### PR DESCRIPTION
## 概要

デフォルト値をこれまでの保守寄り（成長率2%・利回り4%）から、強気シナリオと同じ「成長率1%・利回り7%」に変更しました。

## 変更内容

- `app/page.tsx` の `DEFAULTS` を `growthRate: 1` / `dividendYield: 7` に変更

これにより初期表示と「初期化」ボタンの両方が利回り7%になり、シナリオボタンも「強気」が選択状態で始まります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEWLCQA4eqykxDzW3mnXic

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEWLCQA4eqykxDzW3mnXic)_