### PR TITLE
Pin packageManager to a valid pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "road-to-fire",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@9",
+  "packageManager": "pnpm@10.25.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary

`package.json` declared `"packageManager": "pnpm@9"`, which is **not a valid Corepack version spec** (Corepack requires a full `x.y.z` version). This produced the warning `Cannot switch to pnpm@9: "9" is not a valid version` on every install.

More importantly, Dependabot uses Corepack to activate the specified package manager during its update jobs. Because `pnpm@9` is invalid, Dependabot failed to set up pnpm and **skipped creating security-update PRs entirely** — even for direct dependencies like `next`. This is the likely reason no Dependabot PRs were opened despite security updates being enabled.

## Change

- `"packageManager": "pnpm@9"` → `"pnpm@10.25.0"` (the full version currently used locally / to resolve the lockfile)

## Verification

- `pnpm install` no longer emits the `Cannot switch to pnpm@9` warning